### PR TITLE
revert 'upd TensorRT to 11.1'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,8 +211,6 @@ Knobs under `export:` in `config.yaml`: `half` (FP16), `max_batch_size`, `dynami
 
 ONNX has the D-FINE postprocessor fused into the graph; OpenVINO exports the raw head (postprocess separately).
 
-**TensorRT ≥ 11 is strong-typed** (pinned `tensorrt==11.1`). Precision is authored into the ONNX, not chosen by a builder flag: with `export.half`, the TRT branch fp16-converts the ONNX (via `onnxconverter_common`) while keeping the DFL `Softmax` fp32 — it's precision-sensitive — then builds a strong-typed engine (no `BuilderFlag.FP16`). If a future model has another precision-sensitive op, add it to the `op_block_list` in `export_to_tensorrt`.
-
 **Parity self-check** (`export.parity: True`, default on): after exporting, each backend runs on
 the same input as torch and one cosine per backend — over the sorted top-K detection scores — is
 printed and written to `parity.csv`. Scores are the reorder-stable, end-to-end signal; per-query
@@ -223,12 +221,10 @@ compared (bench covers surviving-box geometry). Warn-gated at cos ≥ 0.99 (≥ 
 
 ```bash
 make ov_int8      # OpenVINO INT8 via NNCF, accuracy-aware (can take hours)
-make trt_int8     # TensorRT INT8 — raises on TRT 11 (see note)
+make trt_int8     # TensorRT INT8 calibration
 ```
 
 OpenVINO path respects `ov_int8_max_drop` (default 0.02 F1 drop allowed).
-
-**`make trt_int8` is broken on TensorRT 11** and raises loudly: TRT 11 removed the PTQ calibrator API it used (`IInt8EntropyCalibrator2`, `BuilderFlag.INT8`, `ILayer.precision`). TRT INT8 now needs a ModelOpt Q/DQ ONNX fed to a strong-typed build — not yet implemented. Other INT8 backends (OpenVINO/CoreML/LiteRT) are unaffected.
 
 ## 11. Testing
 

--- a/README.md
+++ b/README.md
@@ -209,8 +209,6 @@ Enable **DDP** (multi-GPU) by setting `train.ddp.enabled: True` and `train.ddp.n
 
 > **Tip**: FP16 is the best latency/accuracy trade-off for GPU (TensorRT) and CPU (OpenVINO). For Apple Silicon (CoreML), FP32 is faster.
 
-> **TensorRT 11+** engines are strongly-typed: FP16 is baked into the exported ONNX (the DFL softmax stays FP32), not toggled by a builder flag. TensorRT INT8 is not currently supported on TRT 11.
-
 After export, a parity self-check (`export.parity`, on by default) runs each backend on a shared input and writes one cosine per backend — over the sorted top-K detection scores vs torch — to `parity.csv` next to the weights.
 
 ## Inference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "scikit-learn==1.7.0",
     "scipy==1.15.1",
     "tabulate==0.9.0",
-    "tensorrt==11.1.0.106; sys_platform == 'linux'",
+    "tensorrt==10.13.3.9; sys_platform == 'linux'",
     "torch==2.12.1",
     "torchmetrics==1.9.0",
     "torchvision==0.27.1",
@@ -73,3 +73,26 @@ environments = [
     "sys_platform == 'darwin'",
     "sys_platform == 'linux'",
 ]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt"
+version = "10.13.3.9"
+requires-dist = ["tensorrt-cu12==10.13.3.9"]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12"
+version = "10.13.3.9"
+requires-dist = [
+    "tensorrt-cu12-bindings==10.13.3.9",
+    "tensorrt-cu12-libs==10.13.3.9",
+]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12-bindings"
+version = "10.13.3.9"
+requires-dist = []
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12-libs"
+version = "10.13.3.9"
+requires-dist = []

--- a/src/dl/export.py
+++ b/src/dl/export.py
@@ -372,32 +372,12 @@ def export_to_tensorrt(
 
     opt_bs = min(opt_bs, max_batch_size)
 
-    # TRT 11 is strong-typed: precision must be authored into the ONNX, so build the
-    # engine from an fp16 ONNX with the DFL Softmax kept fp32 (precision-sensitive).
-    # TRT 10: use BuilderFlag.FP16 on an FP32 ONNX (autotuner picks fp16 where safe).
-    is_trt11 = not hasattr(trt.BuilderFlag, "FP16")
-    parse_onnx_path = onnx_file_path
-    if half and is_trt11:
-        from onnxconverter_common import float16
-
-        m = onnx.load(str(onnx_file_path))
-        m = float16.convert_float_to_float16(
-            m, keep_io_types=True, op_block_list=[*float16.DEFAULT_OP_BLOCK_LIST, "Softmax"]
-        )
-        parse_onnx_path = onnx_file_path.with_suffix(".fp16.onnx")
-        onnx.save(m, str(parse_onnx_path))
-        logger.info("ONNX converted to fp16 (Softmax kept fp32) for strong-typed TRT")
-
     tr_logger = trt.Logger(trt.Logger.WARNING)
     builder = trt.Builder(tr_logger)
-    if is_trt11:
-        network = builder.create_network()  # strongly typed by default in TRT 11
-    else:
-        net_flags = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
-        network = builder.create_network(net_flags)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
     parser = trt.OnnxParser(network, tr_logger)
 
-    with open(parse_onnx_path, "rb") as model:
+    with open(onnx_file_path, "rb") as model:
         if not parser.parse(model.read()):
             print("ERROR: Failed to parse the ONNX file.")
             for error in range(parser.num_errors):
@@ -405,10 +385,9 @@ def export_to_tensorrt(
             return
 
     config = builder.create_builder_config()
+    # Increase workspace memory to help with larger batch sizes
     config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 2 << 30)  # 2GB
-    if hasattr(config, "builder_optimization_level"):
-        config.builder_optimization_level = 3
-    if half and not is_trt11:
+    if half:
         config.set_flag(trt.BuilderFlag.FP16)
 
     if max_batch_size > 1:
@@ -417,7 +396,7 @@ def export_to_tensorrt(
         input_name = input_tensor.name
 
         # Load ONNX model to get the actual input shape information
-        onnx_model = onnx.load(str(parse_onnx_path))
+        onnx_model = onnx.load(str(onnx_file_path))
 
         # Find the input by name to ensure we get the correct one
         input_shape_proto = None

--- a/src/dl/trt_int8.py
+++ b/src/dl/trt_int8.py
@@ -331,18 +331,6 @@ def main(cfg: DictConfig):
     Build a TensorRT INT8 engine from the ONNX model using the val set for calibration.
     Expects the ONNX file at <save_dir>/model.onnx (the raw one exported by export.py).
     """
-    import tensorrt as trt
-
-    # TRT 11 removed IInt8EntropyCalibrator2, BuilderFlag.INT8, and ILayer.precision —
-    # the whole PTQ-calibration workflow this script relied on. INT8 now needs explicit
-    # Q/DQ nodes via ModelOpt quantization (python -m modelopt.onnx.quantization).
-    if not hasattr(trt, "IInt8EntropyCalibrator2"):
-        raise RuntimeError(
-            f"TensorRT {trt.__version__} dropped the INT8 calibrator API this script uses. "
-            "Use `python -m modelopt.onnx.quantization` to generate a Q/DQ ONNX, then build "
-            "a strongly-typed engine from it."
-        )
-
     cfg.exp = get_latest_experiment_name(cfg.exp, cfg.train.path_to_save)
     save_dir = Path(cfg.train.path_to_save)
 

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,26 @@ supported-markers = [
     "sys_platform == 'linux'",
 ]
 
+[manifest]
+
+[[manifest.dependency-metadata]]
+name = "tensorrt"
+version = "10.13.3.9"
+requires-dist = ["tensorrt-cu12==10.13.3.9"]
+
+[[manifest.dependency-metadata]]
+name = "tensorrt-cu12"
+version = "10.13.3.9"
+requires-dist = ["tensorrt-cu12-bindings==10.13.3.9", "tensorrt-cu12-libs==10.13.3.9"]
+
+[[manifest.dependency-metadata]]
+name = "tensorrt-cu12-bindings"
+version = "10.13.3.9"
+
+[[manifest.dependency-metadata]]
+name = "tensorrt-cu12-libs"
+version = "10.13.3.9"
+
 [[package]]
 name = "about-time"
 version = "4.2.1"
@@ -639,7 +659,7 @@ requires-dist = [
     { name = "scipy", specifier = "==1.15.1" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tabulate", specifier = "==0.9.0" },
-    { name = "tensorrt", marker = "sys_platform == 'linux'", specifier = "==11.1.0.106" },
+    { name = "tensorrt", marker = "sys_platform == 'linux'", specifier = "==10.13.3.9" },
     { name = "torch", specifier = "==2.12.1" },
     { name = "torchmetrics", specifier = "==1.9.0" },
     { name = "torchvision", specifier = "==0.27.1" },
@@ -2949,41 +2969,38 @@ wheels = [
 
 [[package]]
 name = "tensorrt"
-version = "11.1.0.106"
+version = "10.13.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tensorrt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "tensorrt-cu12", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/af/215ec5632aa002fcc061b18f9e16f718a5e3d51d04712713f0a154e2ba07/tensorrt-11.1.0.106.tar.gz", hash = "sha256:18ee99dc9cb0b2c14d12a68e1a062a79699c05a684ae564390130a1293af059a", size = 16664, upload-time = "2026-06-16T17:26:20.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/88/5d4cac975abb19654a6589ce7cd06fab15f6299382b67ba876b9e2438d1f/tensorrt-10.13.3.9.tar.gz", hash = "sha256:89ec5c15c6327c17a9bf592a0801f793c786f45b4f0e0089a3a875d639887fa1", size = 40518, upload-time = "2025-09-05T18:54:22.142Z" }
 
 [[package]]
-name = "tensorrt-cu13"
-version = "11.1.0.106"
+name = "tensorrt-cu12"
+version = "10.13.3.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tensorrt-cu13-bindings", marker = "sys_platform == 'linux'" },
-    { name = "tensorrt-cu13-libs", marker = "sys_platform == 'linux'" },
+    { name = "tensorrt-cu12-bindings", marker = "sys_platform == 'linux'" },
+    { name = "tensorrt-cu12-libs", marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/85/b71d95375f67b3b54450aa1b313d099e69987aaf669f47313abe2da49d5d/tensorrt_cu13-11.1.0.106.tar.gz", hash = "sha256:7511c9fa102306c5841a3a261a18a99eab3a5e4bf2e1f64a34f3331475f8e804", size = 17979, upload-time = "2026-06-16T17:26:20.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/aa/5a630ac02d05f7bbc774bd11b2bc9a3d31aa0bd7d38b4cfeef06733544b3/tensorrt_cu12-10.13.3.9.tar.gz", hash = "sha256:b507abc536ceeaac3b2e6527bd65100bef19000d204e7072db6fe85f9f859a84", size = 18175, upload-time = "2025-09-05T19:03:16.524Z" }
 
 [[package]]
-name = "tensorrt-cu13-bindings"
-version = "11.1.0.106"
+name = "tensorrt-cu12-bindings"
+version = "10.13.3.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/dc/a57c98cbee7d66af75d8cefa03a7a3262430a20d886781b16c430205b5a9/tensorrt_cu13_bindings-11.1.0.106-cp311-none-manylinux_2_28_x86_64.whl", hash = "sha256:14b6073352fddc66fc859956b86a8e601f9a35ce15e8d331026a7f7947e4e683", size = 1240726, upload-time = "2026-06-16T17:28:07.464Z" },
-    { url = "https://files.pythonhosted.org/packages/51/0f/167224b106cea2bd0ce86fe258e567490c04ad15a90b71cad4497a7bb5a5/tensorrt_cu13_bindings-11.1.0.106-cp311-none-manylinux_2_35_aarch64.whl", hash = "sha256:91f8c83f4c8a8e793479d5a619996073d53487dae2ea58cdffbb06744ded8b8f", size = 1227555, upload-time = "2026-06-16T17:28:56.539Z" },
-    { url = "https://files.pythonhosted.org/packages/35/db/3d72889bd9ec71e981869bed490742255bc011c9d0094c73867f83776931/tensorrt_cu13_bindings-11.1.0.106-cp312-none-manylinux_2_28_x86_64.whl", hash = "sha256:c02e93843a7bbe0b1cba15fb1fa01424d240f9037326e66d21628a2f1fcf2bf2", size = 1239408, upload-time = "2026-06-16T17:29:20.619Z" },
-    { url = "https://files.pythonhosted.org/packages/76/aa/3673ea48abfeb5e75ff7566a89e1dc7b8542dd22711c8ff999cef9faf796/tensorrt_cu13_bindings-11.1.0.106-cp312-none-manylinux_2_35_aarch64.whl", hash = "sha256:2b34be566802da851f9fd6cb86428431e5d14ea527405ee86d0e3d3551ea41d3", size = 1214006, upload-time = "2026-06-16T17:29:42.57Z" },
-    { url = "https://files.pythonhosted.org/packages/22/8c/cc33158fbf493959df03869082c734fe47c1b35e206206655b5bb4747af6/tensorrt_cu13_bindings-11.1.0.106-cp313-none-manylinux_2_28_x86_64.whl", hash = "sha256:cc0c63553a3015f1a9c6acdf9883ae636dbeb6607ace40041f4bd45487887cca", size = 1239441, upload-time = "2026-06-16T17:30:25.306Z" },
-    { url = "https://files.pythonhosted.org/packages/92/7f/8d1d9c555839fce2fd28a2466af56944b386f3b351cc8ff7f2aef13491ce/tensorrt_cu13_bindings-11.1.0.106-cp313-none-manylinux_2_35_aarch64.whl", hash = "sha256:4ebbaa9dc5aab768bef1ff1427a0cf5334bbbb5e3438a156e2ba94e4559c55dc", size = 1214005, upload-time = "2026-06-16T17:30:48.112Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b4/9040435df7db4491b6a9dbac68dfd39ba8de9b79e06cc877c064fe97c2a6/tensorrt_cu12_bindings-10.13.3.9-cp311-none-manylinux_2_28_x86_64.whl", hash = "sha256:33aa9d104c04b008871645a97bd8a1a02279cf498d251df5e767d9d5183e0646", size = 1181763, upload-time = "2025-09-05T19:04:50.567Z" },
+    { url = "https://files.pythonhosted.org/packages/58/cc/8eddae7c3b0bd6d51290624c59f05b51ec3ded917b3689f1975f8dcfc601/tensorrt_cu12_bindings-10.13.3.9-cp312-none-manylinux_2_28_x86_64.whl", hash = "sha256:193174cd0aa5ec7d63943d8d3f84ca9ec525477a9db3a9100bf2f77071b3fae8", size = 1184541, upload-time = "2025-09-05T19:04:03.708Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1c/07281273e6db001f726e365b70d7d648df7da0af2da68eabe83f58622f7c/tensorrt_cu12_bindings-10.13.3.9-cp313-none-manylinux_2_28_x86_64.whl", hash = "sha256:90c7d502682d868a918665f1035b4acb07254bcd76cc551febea9a7009ee6269", size = 1184451, upload-time = "2025-09-05T19:04:26.969Z" },
 ]
 
 [[package]]
-name = "tensorrt-cu13-libs"
-version = "11.1.0.106"
+name = "tensorrt-cu12-libs"
+version = "10.13.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/f5/babf00011cdb6bbed9743cc885a39399aebc37197dbb6f8bbe7e03dab7fc/tensorrt_cu13_libs-11.1.0.106.tar.gz", hash = "sha256:6d2fe9e98847775122566c58b32691631dff8d8152b724d92447e93a23dfbefb", size = 15747, upload-time = "2026-06-16T19:40:06.288Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/d3/82b9a603cac94975dbb25d33c7ffb1dba6851980f2dc630f2bf9caf0bffb/tensorrt_cu12_libs-10.13.3.9.tar.gz", hash = "sha256:99d11dd42a27705bcb2ea4e2e0f76817a2a9403d892ec1272c502bd2722ebbd9", size = 703, upload-time = "2025-09-05T18:03:45.78Z" }
 
 [[package]]
 name = "termcolor"


### PR DESCRIPTION
Going back to TensorRT 10.x because of slight accuracy degradation with 11.x and fp16