### PR TITLE
Add optional ultrafast backend for COCO bbox and mask evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ This creates a `.venv/` with the package installed editable and every extra pres
 
 Pretrained weights are auto-downloaded from [Hugging Face](https://huggingface.co/ArgoSA/D-FINE-seg) on first use, so no manual setup is needed - into `pretrained/` for the config-driven commands, and into the shared Hugging Face cache for `load_model("s")` when there is no `pretrained/` copy to reuse. To download manually instead, grab `dfine_<size>_<dataset>.pt` (size ∈ {n, s, m, l, x}, dataset ∈ {coco, obj2coco}) and place it in `pretrained/`. Segmentation weights are also available in the Hugging Face model card.
 
+### Optional faster COCO evaluation
+
+From this source checkout, install the ultrafast backend and select it for training validation:
+
+```bash
+pip install -e '.[ultrafast]'
+dfine train train.coco_backend=ultrafast
+```
+
+`train.coco_backend` defaults to `faster_coco_eval`. The `ultrafast` option uses
+[ultrafast-pycocotools](https://github.com/developer0hye/ultrafast-pycocotools)
+for bbox and instance-segmentation mAP on the CPU. It also applies wherever the
+shared Validator computes mAP, including INT8 validation. F1, threshold sweeps,
+semantic-segmentation metrics and model inference keep their existing computation.
+`dfine bench` currently disables mAP, so changing this option does not accelerate
+its reported inference latency or F1 calculation.
+
+For direct use, pass `coco_backend="ultrafast"` to `Validator`. The adapter changes
+only that metric instance and retains TorchMetrics' update/reset lifecycle.
+Tests compare full bbox/segm evaluation arrays with pycocotools and the existing
+backend, including crowd annotations, tied scores, empty detections and RLE masks.
+
 ### Prepare Your Data
 
 Two annotation formats are supported: **YOLO** (default) and **COCO JSON**. Semantic segmentation uses **PNG masks** instead (see below).

--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,7 @@ train:
   early_stopping: 0 # 0 - no early stopping
   ignore_background_epochs: 0 # background images not used for N epochs in train set. Ignored for sem_seg
   num_workers: 12 # In DDP used per GPU. Go lower if RAM is tight for segmentation
+  coco_backend: faster_coco_eval # faster_coco_eval | ultrafast (install [ultrafast])
   mask_batch_size: 150 # number of images to process at once when computing mask metrics
   freeze_except_mask: False # freeze everything except MaskDecoder
 

--- a/dfine_seg/config/default.yaml
+++ b/dfine_seg/config/default.yaml
@@ -69,6 +69,7 @@ train:
   early_stopping: 0 # 0 - no early stopping
   ignore_background_epochs: 0 # background images not used for N epochs in train set. Ignored for sem_seg
   num_workers: 12 # In DDP used per GPU. Go lower if RAM is tight for segmentation
+  coco_backend: faster_coco_eval # faster_coco_eval | ultrafast (install [ultrafast])
   mask_batch_size: 150 # number of images to process at once when computing mask metrics
   freeze_except_mask: False # freeze everything except MaskDecoder
 

--- a/dfine_seg/dl/bench.py
+++ b/dfine_seg/dl/bench.py
@@ -126,6 +126,7 @@ def test_model(
     label_to_name: Dict[int, str],
     compute_maps: bool,
     to_draw_gt: bool,
+    coco_backend: str = "faster_coco_eval",
 ):
     logger.info(f"Testing {name} model")
     latency = []
@@ -225,6 +226,7 @@ def test_model(
         conf_thresh=conf_thresh,
         iou_thresh=iou_thresh,
         label_to_name=label_to_name,
+        coco_backend=coco_backend,
         compute_maps=compute_maps,  # as inference done with a conf threshold, mAPs don't make much sense
     )
 
@@ -454,6 +456,7 @@ def main(cfg: DictConfig):
                 label_to_name=cfg.train.label_to_name,
                 compute_maps=compute_maps,
                 to_draw_gt=to_draw_gt,
+                coco_backend=getattr(cfg.train, "coco_backend", "faster_coco_eval"),
             )
         del model
         gc.collect()

--- a/dfine_seg/dl/coco_metric.py
+++ b/dfine_seg/dl/coco_metric.py
@@ -1,0 +1,71 @@
+"""Per-metric COCO backend selection; no global import replacement."""
+
+from importlib import import_module
+
+import numpy as np
+from torchmetrics.detection.helpers import CocoBackend
+from torchmetrics.detection.mean_ap import MeanAveragePrecision
+
+
+class _MaskTools:
+    @staticmethod
+    def encode(value):
+        from ultrafast_pycocotools import mask
+
+        # TorchMetrics stores boolean masks; COCO's mask API expects uint8.
+        if value.dtype == np.bool_:
+            value = np.asfortranarray(value, dtype=np.uint8)
+        return mask.encode(value)
+
+    def __getattr__(self, name):
+        from ultrafast_pycocotools import mask
+
+        return getattr(mask, name)
+
+
+class _UltrafastBackend(CocoBackend):
+    @property
+    def coco(self):
+        from ultrafast_pycocotools import COCO
+
+        return COCO
+
+    @property
+    def cocoeval(self):
+        from ultrafast_pycocotools import COCOeval
+
+        return COCOeval
+
+    @property
+    def mask_utils(self):
+        return _MaskTools()
+
+
+def validate_coco_backend(backend: str) -> None:
+    """Reject unavailable backends before starting a training epoch."""
+    if backend not in ("faster_coco_eval", "ultrafast"):
+        raise ValueError("train.coco_backend must be 'faster_coco_eval' or 'ultrafast'")
+    if backend == "ultrafast":
+        try:
+            import_module("ultrafast_pycocotools")
+        except ModuleNotFoundError as exc:
+            if exc.name != "ultrafast_pycocotools":
+                raise
+            raise ModuleNotFoundError(
+                "The ultrafast backend requires: pip install 'dfine-seg[ultrafast]'"
+            ) from exc
+
+
+def coco_metric(iou_type: str, backend: str = "faster_coco_eval") -> MeanAveragePrecision:
+    """Create a fresh bbox/segm metric with TorchMetrics' normal state lifecycle."""
+    validate_coco_backend(backend)
+    metric = MeanAveragePrecision(
+        box_format="xyxy", iou_type=iou_type, sync_on_compute=False, backend="faster_coco_eval"
+    )
+    if backend == "ultrafast":
+        # TorchMetrics 1.9 exposes no public custom-backend constructor argument.
+        if not isinstance(getattr(metric, "_coco_backend", None), CocoBackend):
+            raise RuntimeError("Unsupported TorchMetrics COCO backend layout")
+        metric._coco_backend = _UltrafastBackend("faster_coco_eval")
+    metric.warn_on_many_detections = False
+    return metric

--- a/dfine_seg/dl/ov_int8.py
+++ b/dfine_seg/dl/ov_int8.py
@@ -128,6 +128,7 @@ def main(cfg: DictConfig):
             label_to_name=label_to_name,
             conf_thresh=conf_thresh,
             iou_thresh=iou_thresh,
+            coco_backend=getattr(cfg.train, "coco_backend", "faster_coco_eval"),
         )
         metrics = validator.compute_metrics(extended=False)
         f1_score = metrics["f1"]

--- a/dfine_seg/dl/train.py
+++ b/dfine_seg/dl/train.py
@@ -40,6 +40,7 @@ from dfine_seg.model.dist_utils import (
 )
 from dfine_seg.model.utils import save_checkpoint, unwrap_checkpoint
 from dfine_seg.dl.dataset import Loader
+from dfine_seg.dl.coco_metric import validate_coco_backend
 from dfine_seg.dl.utils import (
     auto_batch_size,
     calculate_remaining_time,
@@ -104,6 +105,9 @@ class ModelEMA:
 class Trainer:
     def __init__(self, cfg: DictConfig) -> None:
         self.cfg = cfg
+        self.coco_backend = getattr(cfg.train, "coco_backend", "faster_coco_eval")
+        if cfg.task != "sem_seg":
+            validate_coco_backend(self.coco_backend)
 
         # Only consider distributed if config says DDP enabled AND process group was initialized
         self.distributed = (
@@ -627,6 +631,7 @@ class Trainer:
                     iou_thresh=iou_thresh,
                     label_to_name=self.label_to_name,
                     mask_batch_size=self.mask_batch_size,
+                    coco_backend=self.coco_backend,
                 )
                 metrics = validator.compute_metrics(extended=extended)
             if path_to_save:  # val and test

--- a/dfine_seg/dl/trt_int8.py
+++ b/dfine_seg/dl/trt_int8.py
@@ -183,6 +183,7 @@ def validate_engine(
     label_to_name: dict,
     enable_mask_head: bool,
     input_size: tuple,  # (H, W)
+    coco_backend: str = "faster_coco_eval",
 ) -> float:
     """
     Load an engine, run the val set through it, return the F1 score.
@@ -303,6 +304,7 @@ def validate_engine(
         label_to_name=label_to_name,
         conf_thresh=conf_thresh,
         iou_thresh=iou_thresh,
+        coco_backend=coco_backend,
     )
     metrics = validator.compute_metrics(extended=False)
     f1 = metrics["f1"]
@@ -390,6 +392,7 @@ def main(cfg: DictConfig):
             label_to_name=label_to_name,
             enable_mask_head=enable_mask_head,
             input_size=tuple(cfg.train.img_size),
+            coco_backend=getattr(cfg.train, "coco_backend", "faster_coco_eval"),
         )
         logger.info(f"Final INT8 F1: {f1:.4f}")
 

--- a/dfine_seg/dl/validator.py
+++ b/dfine_seg/dl/validator.py
@@ -9,9 +9,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from loguru import logger
-from torchmetrics.detection.mean_ap import MeanAveragePrecision
 from torchvision.ops import box_iou
 
+from dfine_seg.dl.coco_metric import coco_metric
 from dfine_seg.dl.utils import filter_preds, rle_to_masks
 
 # Suppress verbose output from faster_coco_eval
@@ -28,6 +28,7 @@ class Validator:
         iou_thresh=0.5,
         mask_batch_size=1000,
         compute_maps=True,
+        coco_backend="faster_coco_eval",
     ) -> None:
         """
         Format example:
@@ -36,7 +37,8 @@ class Validator:
         bboxes are in format [x1, y1, x2, y2], absolute values
 
         mask_batch_size - Number of images to process at once when computing mask metrics.
-            Lower values use less RAM but may be slower. Default 500.
+            Lower values use less RAM but may be slower. Default 1000.
+        coco_backend - "faster_coco_eval" (default) or "ultrafast" (requires [ultrafast]).
         """
         self.gt = gt
         self.preds = preds
@@ -50,11 +52,7 @@ class Validator:
         self.mask_batch_size = mask_batch_size
         self.compute_maps = compute_maps
 
-        # Use faster_coco_eval backend for numpy 2.x compatibility
-        self.torch_metric = MeanAveragePrecision(
-            box_format="xyxy", iou_type="bbox", sync_on_compute=False, backend="faster_coco_eval"
-        )
-        self.torch_metric.warn_on_many_detections = False
+        self.torch_metric = coco_metric("bbox", coco_backend)
 
         # get raw preds for torchmetrics (only needed when computing mAPs; the deepcopy
         # duplicates every dense mask, so skip it otherwise to avoid an OOM spike)
@@ -81,13 +79,7 @@ class Validator:
 
         self.use_masks = any(_has_masks(p) for p in preds) and any(_has_masks(g) for g in gt)
         if self.use_masks and self.compute_maps:
-            self.torch_metric_mask = MeanAveragePrecision(
-                box_format="xyxy",
-                iou_type="segm",
-                sync_on_compute=False,
-                backend="faster_coco_eval",
-            )
-            self.torch_metric_mask.warn_on_many_detections = False
+            self.torch_metric_mask = coco_metric("segm", coco_backend)
             # Decode RLE masks for torchmetrics in batches to avoid OOM
             # torchmetrics supports incremental .update() calls
             batch_size = self.mask_batch_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Optional CPU evaluator for bbox and instance-segmentation mAP.
+ultrafast = ["ultrafast-pycocotools>=0.1.9,<0.2"]
 # `make export` / `dfine export` backends. Large, so opt-in. nncf and openvino are
 # capped at the tested major: a silent API change there yields a bad artifact, not an error.
 export = [
@@ -83,6 +85,7 @@ extra = [
     "pillow-heif>=1.4.0",
 ]
 all = [
+    "dfine-seg[ultrafast]",
     "dfine-seg[export]",
     "dfine-seg[trt]",
     "dfine-seg[label]",
@@ -120,6 +123,7 @@ dev = [
     "dfine-seg[all]",
     "pre-commit>=4.6.0",
     "pytest>=8",
+    "pycocotools>=2.0.11",
     "pytest-xdist>=3",
     "ruff==0.15.20",
 ]

--- a/tests/integration/test_light_import.py
+++ b/tests/integration/test_light_import.py
@@ -30,6 +30,7 @@ FORBIDDEN = [
     "sklearn",
     "torchmetrics",
     "faster_coco_eval",
+    "ultrafast_pycocotools",
 ]
 
 

--- a/tests/integration/test_pretrained_accuracy.py
+++ b/tests/integration/test_pretrained_accuracy.py
@@ -59,7 +59,10 @@ def _load_yolo_labels(
 
 
 @pytest.mark.slow
-def test_pretrained_s_cpu_mAP_holds_baseline(coco_pretrained_path):
+@pytest.mark.parametrize("coco_backend", ["faster_coco_eval", "ultrafast"])
+def test_pretrained_s_cpu_mAP_holds_baseline(coco_pretrained_path, coco_backend):
+    if coco_backend == "ultrafast":
+        pytest.importorskip("ultrafast_pycocotools")
     baseline = _require_fixtures()
     # Only images with a matching label file count as fixture inputs — that's
     # what the bootstrap writes, and it lets stray source images sit in the
@@ -104,6 +107,7 @@ def test_pretrained_s_cpu_mAP_holds_baseline(coco_pretrained_path):
         gt.append({"labels": gt_labels, "boxes": gt_boxes})
 
     v = Validator(
+        coco_backend=coco_backend,
         gt=copy.deepcopy(gt),
         preds=copy.deepcopy(preds),
         label_to_name=COCO80,

--- a/tests/unit/test_coco_backend.py
+++ b/tests/unit/test_coco_backend.py
@@ -1,0 +1,142 @@
+"""Exercise the optional backend through TorchMetrics and the real Validator."""
+
+import copy
+import pickle
+
+import pytest
+import torch
+from torchmetrics.detection.mean_ap import MeanAveragePrecision
+
+from dfine_seg.dl.coco_metric import coco_metric
+from dfine_seg.dl.utils import encode_sample_masks_to_rle
+from dfine_seg.dl.validator import Validator
+
+
+def samples():
+    gt, preds = [], []
+    for index in range(5):
+        boxes = torch.tensor([[2.0, 3.0, 18.0, 20.0], [12.0, 10.0, 28.0, 30.0]])
+        masks = torch.zeros((2, 32, 32), dtype=torch.bool)
+        masks[0, 3:20, 2:18] = True
+        masks[1, 10:30, 12:28] = True
+        n_gt = 0 if index in (3, 4) else 2
+        n_dt = 0 if index in (2, 4) else 2
+        gt.append(
+            {
+                "boxes": boxes[:n_gt].clone(),
+                "labels": torch.tensor([0, 1])[:n_gt],
+                "masks": masks[:n_gt].clone(),
+                "iscrowd": torch.tensor([0, index % 2])[:n_gt],
+                "area": torch.tensor([272.0, 320.0])[:n_gt],
+            }
+        )
+        preds.append(
+            {
+                "boxes": boxes[:n_dt].clone() + index,
+                "labels": torch.tensor([0, 1])[:n_dt],
+                "scores": torch.tensor([0.8, 0.8])[:n_dt],
+                "masks": torch.roll(masks[:n_dt], shifts=index, dims=-1),
+            }
+        )
+    return gt, preds
+
+
+@pytest.mark.parametrize("iou_type", ["bbox", "segm"])
+def test_full_arrays_and_metric_lifecycle(iou_type):
+    pytest.importorskip("ultrafast_pycocotools")
+    pytest.importorskip("pycocotools")
+    gt, preds = samples()
+    reference = MeanAveragePrecision(
+        box_format="xyxy", iou_type=iou_type, sync_on_compute=False, backend="pycocotools"
+    )
+    fast = coco_metric(iou_type, "ultrafast")
+    existing = coco_metric(iou_type)
+    assert existing._coco_backend.coco.__module__.startswith("faster_coco_eval")
+    assert fast._coco_backend.coco.__module__.startswith("ultrafast_pycocotools")
+    for metric in (reference, fast, existing):
+        metric.extended_summary = True
+        metric.class_metrics = True
+        # Incremental updates exercise the mask-batch path used by Validator.
+        metric.update(copy.deepcopy(preds[:2]), copy.deepcopy(gt[:2]))
+        metric.update(copy.deepcopy(preds[2:]), copy.deepcopy(gt[2:]))
+    expected = reference.compute()
+    actual = fast.compute()
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)
+    for key in ("precision", "recall", "scores"):
+        assert actual[key].numpy().tobytes() == expected[key].numpy().tobytes()
+    torch.testing.assert_close(existing.compute(), expected, rtol=0, atol=1e-12, equal_nan=True)
+    restored = pickle.loads(pickle.dumps(fast))
+    torch.testing.assert_close(restored.compute(), expected, rtol=0, atol=0, equal_nan=True)
+    for metric in (fast, restored):
+        metric.reset()
+        metric.update(copy.deepcopy(preds), copy.deepcopy(gt))
+        torch.testing.assert_close(metric.compute(), expected, rtol=0, atol=0, equal_nan=True)
+
+
+@pytest.mark.parametrize("encoding", ["bbox", "dense", "rle"])
+def test_validator_metrics_match_existing_backend(encoding):
+    pytest.importorskip("ultrafast_pycocotools")
+    gt, preds = samples()
+    # Validator's F1 code expects binary uint8 masks, matching training outputs.
+    for item in gt + preds:
+        item["masks"] = item["masks"].to(torch.uint8)
+        if encoding == "bbox":
+            del item["masks"]
+        elif encoding == "rle":
+            encode_sample_masks_to_rle(item)
+    outputs = []
+    for backend in ("faster_coco_eval", "ultrafast"):
+        validator = Validator(
+            copy.deepcopy(gt),
+            copy.deepcopy(preds),
+            {0: "cat", 1: "dog"},
+            coco_backend=backend,
+            mask_batch_size=2,
+        )
+        outputs.append(validator.compute_metrics(extended=True))
+        assert validator.torchmetrics_preds is None
+        assert len(validator.torch_metric.detection_labels) == 0
+    assert outputs[0].keys() == outputs[1].keys()
+    for key in outputs[0]:
+        assert outputs[1][key] == pytest.approx(outputs[0][key]), key
+
+
+def test_unknown_backend_rejected():
+    with pytest.raises(ValueError, match="train.coco_backend"):
+        coco_metric("bbox", "typo")
+
+
+def test_invalid_backend_fails_before_training_setup():
+    from omegaconf import OmegaConf
+
+    from dfine_seg.dl.train import Trainer
+
+    cfg = OmegaConf.create({"task": "detect", "train": {"coco_backend": "typo"}})
+    with pytest.raises(ValueError, match="train.coco_backend"):
+        Trainer(cfg)
+
+
+def test_missing_optional_dependency_is_actionable(monkeypatch):
+    from dfine_seg.dl import coco_metric as module
+
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(module, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match=r"dfine-seg\[ultrafast\]"):
+        coco_metric("bbox", "ultrafast")
+    # The optional package must not be required by the default backend.
+    assert coco_metric("bbox")._coco_backend.coco.__module__.startswith("faster_coco_eval")
+
+
+def test_no_maps_still_returns_f1(synthetic_preds_gt):
+    pytest.importorskip("ultrafast_pycocotools")
+    validator = Validator(
+        copy.deepcopy(synthetic_preds_gt["gt"]),
+        copy.deepcopy(synthetic_preds_gt["preds"]),
+        {0: "cat", 1: "dog"},
+        coco_backend="ultrafast",
+        compute_maps=False,
+    )
+    result = validator.compute_metrics()
+    assert "f1" in result and "mAP_50" not in result

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ all = [
     { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tensorrt", marker = "sys_platform == 'linux'" },
     { name = "transformers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "ultrafast-pycocotools", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 demo = [
     { name = "gradio", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -610,11 +611,15 @@ label = [
 trt = [
     { name = "tensorrt", marker = "sys_platform == 'linux'" },
 ]
+ultrafast = [
+    { name = "ultrafast-pycocotools", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "dfine-seg", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pre-commit", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "pycocotools", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pytest-xdist", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -629,6 +634,7 @@ requires-dist = [
     { name = "dfine-seg", extras = ["extra"], marker = "extra == 'all'", editable = "." },
     { name = "dfine-seg", extras = ["label"], marker = "extra == 'all'", editable = "." },
     { name = "dfine-seg", extras = ["trt"], marker = "extra == 'all'", editable = "." },
+    { name = "dfine-seg", extras = ["ultrafast"], marker = "extra == 'all'", editable = "." },
     { name = "difpy", marker = "extra == 'extra'", specifier = ">=4.2.1" },
     { name = "faster-coco-eval", specifier = ">=1.6.5" },
     { name = "gradio", marker = "extra == 'demo'", specifier = ">=6.16.0,<7" },
@@ -661,14 +667,16 @@ requires-dist = [
     { name = "torchvision", specifier = ">=0.28.0" },
     { name = "tqdm", specifier = ">=4.66.5" },
     { name = "transformers", marker = "extra == 'label'", specifier = ">=5.15.0" },
+    { name = "ultrafast-pycocotools", marker = "extra == 'ultrafast'", specifier = ">=0.1.9,<0.2" },
     { name = "wandb", specifier = ">=0.26.1" },
 ]
-provides-extras = ["export", "trt", "label", "demo", "extra", "all"]
+provides-extras = ["ultrafast", "export", "trt", "label", "demo", "extra", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "dfine-seg", extras = ["all"], editable = "." },
     { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pycocotools", specifier = ">=2.0.11" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-xdist", specifier = ">=3" },
     { name = "ruff", specifier = "==0.15.20" },
@@ -2018,6 +2026,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pycocotools"
+version = "2.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/df/32354b5dda963ffdfc8f75c9acf8828ef7890723a4ed57bb3ff2dc1d6f7e/pycocotools-2.0.11.tar.gz", hash = "sha256:34254d76da85576fcaf5c1f3aa9aae16b8cb15418334ba4283b800796bd1993d", size = 25381, upload-time = "2025-12-15T22:31:46.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/3f/41ce3fce61b7721158f21b61727eb054805babc0088cfa48506935b80a36/pycocotools-2.0.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:81bdceebb4c64e9265213e2d733808a12f9c18dfb14457323cc6b9af07fa0e61", size = 158947, upload-time = "2025-12-15T22:31:03.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9b/a739705b246445bd1376394bf9d1ec2dd292b16740e92f203461b2bb12ed/pycocotools-2.0.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c05f91ccc658dfe01325267209c4b435da1722c93eeb5749fabc1d087b6882", size = 485174, upload-time = "2025-12-15T22:31:04.395Z" },
+    { url = "https://files.pythonhosted.org/packages/34/70/7a12752784e57d8034a76c245c618a2f88a9d2463862b990f314aea7e5d6/pycocotools-2.0.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18ba75ff58cedb33a85ce2c18f1452f1fe20c9dd59925eec5300b2bf6205dbe1", size = 493172, upload-time = "2025-12-15T22:31:05.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fc/d703599ac728209dba08aea8d4bee884d5adabfcd9041abed1658d863747/pycocotools-2.0.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:693417797f0377fd094eb815c0a1e7d1c3c0251b71e3b3779fce3b3cf24793c5", size = 480506, upload-time = "2025-12-15T22:31:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d9/e1cfc320bbb2cd58c3b4398c3821cbe75d93c16ed3135ac9e774a18a02d3/pycocotools-2.0.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6a07071c441d0f5e480a8f287106191582e40289d4e242dfe684e0c8a751088", size = 497595, upload-time = "2025-12-15T22:31:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/87/12/2f2292332456e4e4aba1dec0e3de8f1fc40fb2f4fdb0ca1cb17db9861682/pycocotools-2.0.11-cp312-abi3-macosx_10_13_universal2.whl", hash = "sha256:a2e9634bc7cadfb01c88e0b98589aaf0bd12983c7927bde93f19c0103e5441f4", size = 147795, upload-time = "2025-12-15T22:31:11.519Z" },
+    { url = "https://files.pythonhosted.org/packages/63/3c/68d7ea376aada9046e7ea2d7d0dad0d27e1ae8b4b3c26a28346689390ab2/pycocotools-2.0.11-cp312-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fd4121766cc057133534679c0ec3f9023dbd96e9b31cf95c86a069ebdac2b65", size = 398434, upload-time = "2025-12-15T22:31:12.558Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/dc81895beff4e1207a829d40d442ea87cefaac9f6499151965f05c479619/pycocotools-2.0.11-cp312-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a82d1c9ed83f75da0b3f244f2a3cf559351a283307bd9b79a4ee2b93ab3231dd", size = 411685, upload-time = "2025-12-15T22:31:13.995Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0b/5a8a7de300862a2eb5e2ecd3cb015126231379206cd3ebba8f025388d770/pycocotools-2.0.11-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:89e853425018e2c2920ee0f2112cf7c140a1dcf5f4f49abd9c2da112c3e0f4b3", size = 390500, upload-time = "2025-12-15T22:31:15.138Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b5/519bb68647f06feea03d5f355c33c05800aeae4e57b9482b2859eb00752e/pycocotools-2.0.11-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:87af87b8d06d5b852a885a319d9362dca3bed9f8bbcc3feb6513acb1f88ea242", size = 409790, upload-time = "2025-12-15T22:31:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/31c81e99d596a20c137d8a2e7a25f39a88f88fada5e0b253fce7323ecf0d/pycocotools-2.0.11-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fd72b9734e6084b217c1fc3945bfd4ec05bdc75a44e4f0c461a91442bb804973", size = 168931, upload-time = "2025-12-15T22:31:19.845Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/63/fdd488e4cd0fdc6f93134f2cd68b1fce441d41566e86236bf6156961ef9b/pycocotools-2.0.11-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7eb43b79448476b094240450420b7425d06e297880144b8ea6f01e9b4340e43", size = 484856, upload-time = "2025-12-15T22:31:21.231Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fc/c83648a8fb7ea3b8e2ce2e761b469807e6cadb81577bf1af31c4f2ef0d87/pycocotools-2.0.11-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3546b93b39943347c4f5b0694b5824105cbe2174098a416bcad4acd9c21e957", size = 480994, upload-time = "2025-12-15T22:31:22.426Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2d/35e1122c0d007288aa9545be9549cbc7a4987b2c22f21d75045260a8b5b8/pycocotools-2.0.11-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:efd1694b2075f2f10c5828f10f6e6c4e44368841fd07dae385c3aa015c8e25f9", size = 467956, upload-time = "2025-12-15T22:31:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ff/30cfe8142470da3e45abe43a9842449ca0180d993320559890e2be19e4a5/pycocotools-2.0.11-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:368244f30eb8d6cae7003aa2c0831fbdf0153664a32859ec7fbceea52bfb6878", size = 474658, upload-time = "2025-12-15T22:31:24.883Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2968,6 +3002,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "ultrafast-pycocotools"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/29/b6d11598e63aa00f102729333ea290c84d08bd9af063b56dea93b18d4122/ultrafast_pycocotools-0.1.9.tar.gz", hash = "sha256:f81245f6463968bf9c20814251569a9ff4d352a7a43f24bfdbb0561400701d54", size = 93339, upload-time = "2026-09-08T21:03:27.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e7/54d94f2b49f21b0e1b6bf7a90d4941bd1dec709f5f8c137d22a8344241d2/ultrafast_pycocotools-0.1.9-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b83dcf869047f32b66e5aad99f11e3929ca5da5dfd40529c83f27a3faf0b896b", size = 565239, upload-time = "2026-09-08T21:02:38.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ae/b9880d692f5b23e1cd150204e7653b9abea6863bf3ee27d258d7b5653ec1/ultrafast_pycocotools-0.1.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aa58b223f85928032af28605ddcc8adb839293526da8a5e7a914ac780aab30b5", size = 546537, upload-time = "2026-09-08T21:02:39.517Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/43e80eebc5925dbc0351a0ffd29610daaa906f7b73c9be1b5c578687ff7e/ultrafast_pycocotools-0.1.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e913a99eac76e24dbc00035d6f5a742021c9b9f9f4615192d711826c8549638", size = 572092, upload-time = "2026-09-08T21:02:41.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ea/eebd3c3542d132f3f3f0c4b627e22a3e8e2df1dfe4966a40a42710041f2a/ultrafast_pycocotools-0.1.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bc32fe437059924e5883d7e31f3777becdc95f69325fa53e7cd5b93016ef818", size = 607332, upload-time = "2026-09-08T21:02:42.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/99/0a1fddc6a4b00c5585c6759b9b509cf6b2e83ed8b2b4dcf1f68e271797b0/ultrafast_pycocotools-0.1.9-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c4fdccc700bfe8f6d7196c9f8fd8bfd43a75c1c1f6780fa081a96004bdcab5e4", size = 572955, upload-time = "2026-09-08T21:02:46.217Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/39/e84d23955ce3a4fc561953427cab8c5cbaed703c2b812f2943de34274e5c/ultrafast_pycocotools-0.1.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed7e03d407dc9ea62f1b7b8e536c1ae575aab1a603f2073f942f5f488d2fe6b2", size = 542329, upload-time = "2026-09-08T21:02:47.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1e/336a39593e505f65efaeae41a9cda9dc1bb2e2df96b307b11a0f7f2dfe61/ultrafast_pycocotools-0.1.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bf1252ff302a7b1b113900a3921b50bc06a3f4ddf5928017e3c00666dc7a6e7", size = 570368, upload-time = "2026-09-08T21:02:49.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bd/104a0fe4402adb42d4e5db55b1554c2a154d0d4cc5a00e02c40742cb2073/ultrafast_pycocotools-0.1.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e12fcca664278408a3cce3dd67902f42846771e7991bac63a8b2dcfdd521fc41", size = 605836, upload-time = "2026-09-08T21:02:51.034Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/91/f3d72cf0eb6dd58dc0ac430fcc7e6f175b00974ff89c424a70a9d15530a4/ultrafast_pycocotools-0.1.9-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a7f2972f2bf21f3c197225b3ff8ebd66d853c8cc96ec7029464e40770c8d6691", size = 572852, upload-time = "2026-09-08T21:02:54.319Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a9/04cfc0ba2f006b35ca0acd6d0ed82d2a10bdc98729cbb87eb9e75a3de3c7/ultrafast_pycocotools-0.1.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3409646068fb55439878b540bd6f9e86d342ccd8e62106562b673a0f9f046f36", size = 542246, upload-time = "2026-09-08T21:02:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8e/846d8860154d1e7f9c114626d8df85b3f908f5b5726cc437e388c9f2a7bd/ultrafast_pycocotools-0.1.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59ad92e7cfa1c4cd6862aefc9e606879471fa714a30a036a930a2c226c3956b9", size = 570125, upload-time = "2026-09-08T21:02:57.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e8/873aa59b726dfa59bcb0e0cd685324900f9e08ac7469c7773219d9253761/ultrafast_pycocotools-0.1.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbc9ecea51e7b1e469bd048c7c40fa3a5dc74dcc8a5f4c4c70d954f6737a8e52", size = 605723, upload-time = "2026-09-08T21:02:58.834Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add an optional `train.coco_backend=ultrafast` evaluator for bbox and instance-segmentation mAP. Training, the shared Validator, and INT8 validation forward the selection consistently. Existing configurations keep `faster_coco_eval` as the default.

The per-metric adapter retains TorchMetrics updates, reset/reuse and serialization, and converts boolean masks to the COCO uint8 format. The `ultrafast` extra requires the public `ultrafast-pycocotools>=0.1.9,<0.2` wheels. Unavailable dependencies and unknown selections fail with actionable errors before training setup. Package imports remain torch-only.

Validation on Apple M2, Python 3.12, the locked NumPy 2.1.1/SciPy environment and the public 0.1.9 wheel:

- 273 fast CPU tests pass; 10 optional export/Gradio/SAM3 cases skipped, 18 slow/GPU cases excluded.
- 11 backend and pretrained-accuracy tests pass, including bbox, dense/RLE masks, crowds, tied scores, complete precision/recall/score arrays, per-class outputs, incremental updates, pickle/reset and both backends on pretrained image fixtures.
- Ruff lint/format, `uv lock --check`, wheel and sdist builds pass. Both distributions include the adapter and default backend setting; the sdist excludes the developer root configuration.

Earlier [COCO500 Validator benchmarks](https://github.com/developer0hye/ultrafast-pycocotools/blob/f996418e02ed86690bc0670a6ae2407e9c4cd595/docs/benchmark-dfine-seg.md) and [mask-encoder follow-up](https://github.com/developer0hye/ultrafast-pycocotools/blob/f996418e02ed86690bc0670a6ae2407e9c4cd595/docs/mask-encoding-optimization.md) document M2 and i5-10400/RTX 3070 measurements, including a rejected slower release and the subsequent fix. Those performance measurements used the explicitly identified earlier versions; the tests above validate this PR with 0.1.9. No full training-epoch or distributed GPU speedup is claimed. `dfine bench` retains `compute_maps=False`, so its inference/F1 timings are unaffected.
